### PR TITLE
#ENH improved support for GE P-files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,3 +78,19 @@ Solving specific problems
 
 :doc:`topics/pfiles`
     How to enable support for GE P-files.
+
+All the rest
+============
+
+.. toctree::
+   :caption: All the rest
+   :hidden:
+
+   news
+   topics/contributing
+
+:doc:`news`
+    See what has changed in recent OpenMRSLab versions.
+
+:doc:`topics/contributing`
+    Learn how to contribute to the OpenMRSLab project.

--- a/docs/topics/pfiles.rst
+++ b/docs/topics/pfiles.rst
@@ -3,3 +3,69 @@
 ======================
 Support for GE P-files
 ======================
+
+Support for GE P-files in Suspect is provided by the GE Orchestra library.
+This has the advantage of maximum compatibility with the many P-file revisions
+out there, but the disadvantage that Orchestra is not a freely distributable
+library: GE's current license prohibits the sharing of even the compiled
+library. Therefore, in order to enable P-file support, you must download the
+Orchestra library yourself and add it to the OpenMRSLab Docker container. This
+is a relatively simple process, and the rest of this page gives a detailed
+guide to the necessary steps.
+
+##################################################
+Step 1. Register for a GE MR Collaboration account
+##################################################
+Go to the GE MR Collaboration Community `website
+<https://collaborate.mr.gehealthcare.com/welcome>`_ and register for an
+account. This account is free, but only available for users of GE scanners,
+so there is a manual confirmation step which may take a day or two before your
+account is active. As well as letting you download Orchestra, this account will
+also give you access to GE's MR forums.
+
+#########################################
+Step 2. Download the Orchestra Python SDK
+#########################################
+On the GE MR Collaboration website, go to
+https://collaborate.mr.gehealthcare.com/docs/DOC-1727 to download the Orchestra
+SDK for Python (current version tested with Suspect is v1.10 on 01/10/20). This
+is a rather large download at around 416MB, this is mostly due to the large
+amount of sample data included with the code, the actual code library is only
+10% of that, unfortunately there is no way to get only the SDK itself.
+
+#####################################
+Step 3. Copy the code into OpenMRSLab
+#####################################
+After extracting the Orchestra files from the downloaded archive, you will find
+that as well as the example processing scripts and datasets, there are several
+versions of the code library, covering Windows, MacOS and Linux. The file that
+we need is the Linux version called GERecon.so.python35. This is because the
+OpenMRSLab Docker container is based on Linux, no matter what the host
+operating system for your computer is.
+
+Inside the Docker container, OpenMRSLab is already set up to look for the
+Orchestra .so file in a directory at the path: `/home/jovyan/work/orchestra`.
+If you have followed the recommended approach of mapping a host directory to
+the `/home/jovyan/work` directory then the simplest solution is simply to
+create a folder called `orchestra` in that mapped directory and copy the
+GERecon.so.python35 file into it. Note that it is important to rename the file
+GERecon.so (dropping the .python35 part) to allow Python to recognise and load
+it.
+
+If you do not have a mapped directory, or if you are accessing your OpenMRSLab
+installation remotely and don't have easy access to the host computer file
+system then it is also possible to upload the file through the Jupyter server
+itself. The home directory for the Jupyter server is /home/jovyan/work so
+using the Jupyter file browser interface you can first select New->Folder (from
+the top right hand corner of the interface) and name the resulting folder
+`orchestra`, then click Upload (next to the New button) and select the
+GERecon.so.python35 file from your local system. Again, note that it is
+important to rename the file to GERecon.so.
+
+#############################
+Step 4. Test the installation
+#############################
+To test your installation, simply open a Jupyter notebook and run
+`import GERecon`. If you have correctly installed the SDK then this will
+complete without an error, and you will then be able to use Suspect to work
+with GE P-files.


### PR DESCRIPTION
The previous approach to supporting GE P-files was to have users
build a derived Docker image which would both set up the necessary
foundations for Orchestra to run, then copy in a local version of the
SDK (which cannot be distributed with OpenMRSLab). This was a bit clunky
so now we include the foundation steps (building an updated version of
OpenSSL and renaming some of the libraries) in stock OpenMRSLab, as this
does not break anything else, and adding a hypothetical "orchestra"
folder inside the Jupyter work directory to the PythonPath. Thus all the
user needs to do now is create that folder, either through a mapped
folder or uploading via Jupyter itself, and copy the SDK into it.

We have also taken the opportunity to update the Jupyter base container
which is now running on Ubuntu 20.04, and Python 3.8. GCC has been
downgraded from the default of 9 back to 8 as there are some issues
compiling NiftyReg with version 9 (which relate to OpenMP in some way).

We also upgrade to Suspect v0.4.3.

Closes #5